### PR TITLE
Allow accessory and ring as valid item type inputs

### DIFF
--- a/src/chatCommands/sort.ts
+++ b/src/chatCommands/sort.ts
@@ -77,12 +77,15 @@ const command: ChatCommandData = {
             );
 
         let itemType: SortableItemType;
+        let sortExpression: SortExpressionData;
         if (inputItemType === 'wep') itemType = ItemTypes.WEAPON;
         // "accessorie" because the trailing s would have been removed
         else if (inputItemType === 'helmet') itemType = ItemTypes.HELM;
         else if (inputItemType === 'wing') itemType = ItemTypes.CAPE;
-        else if (['accessorie', 'acc', 'item', 'all', 'all items'].includes(inputItemType)) {
-            const sortExpression: SortExpressionData = parseSortExpression(inputSortExp);
+        else if (
+            ['accessory', 'accessorie', 'acc', 'item', 'all', 'all items'].includes(inputItemType)
+        ) {
+            sortExpression = parseSortExpression(inputSortExp);
             const itemTypes: SortableItemType[] = [
                 ItemTypes.WEAPON,
                 ItemTypes.HELM,
@@ -93,7 +96,7 @@ const command: ChatCommandData = {
                 ItemTypes.TRINKET,
                 ItemTypes.BRACER,
             ];
-            if (inputItemType === 'acc' || inputItemType === 'accessorie') itemTypes.shift();
+            if (['acc', 'accessorie', 'accessory'].includes(inputItemType)) itemTypes.shift();
             await channel.send(
                 multiItemDisplayMessage(itemTypes, {
                     ascending: commandName === 'sortasc',
@@ -115,7 +118,7 @@ const command: ChatCommandData = {
             itemType = inputItemType as SortableItemType;
         }
 
-        const sortExpression: SortExpressionData = parseSortExpression(inputSortExp);
+        sortExpression = parseSortExpression(inputSortExp);
 
         const sortFilters: SortFilterParams = {
             ascending: commandName === 'sortasc',

--- a/src/commonTypes/items.ts
+++ b/src/commonTypes/items.ts
@@ -18,6 +18,7 @@ export const allItemTypes: Set<ItemTypes> = new Set([
     ItemTypes.WINGS,
     ItemTypes.HELM,
     ItemTypes.BELT,
+    ItemTypes.RING,
     ItemTypes.NECKLACE,
     ItemTypes.TRINKET,
     ItemTypes.BRACER,


### PR DESCRIPTION
- Allow the word 'accessory' to be used as a valid input to the sort chat command
- Fix not being able to sort 'rings' explicitly