### PR TITLE
Change embed size limits

### DIFF
--- a/src/commonTypes/commandStructures.ts
+++ b/src/commonTypes/commandStructures.ts
@@ -8,9 +8,9 @@ import {
     MessageComponentTypeResolvable,
 } from 'discord.js';
 
-export const MAX_EMBED_DESC_LENGTH = 2048;
-export const MAX_EMBED_FOOTER_LENGTH = 2048;
-export const MAX_SPLIT_EMBED_DESC_LENGTH = 2020;
+export const MAX_EMBED_DESC_LENGTH = 4096;
+export const MAX_SPLIT_EMBED_DESC_LENGTH = 4070;
+export const MAX_EMBED_FOOTER_LENGTH = 1904;
 
 export const ApplicationCommandOptions: {
     [type: string]: ApplicationCommandOptionType;


### PR DESCRIPTION
Discord embed description size limit was recently increased to 4096 from 2048. Change embed field limit constant values accordingly.