### PR TITLE
Show other variant levels and similar results in pet search results

### DIFF
--- a/src/interactionLogic/search/pets.ts
+++ b/src/interactionLogic/search/pets.ts
@@ -146,7 +146,8 @@ function formatQueryResponse(responseBody: any): {
 
 export async function getPetSearchResult(
     term: string,
-    maxLevel?: number
+    maxLevel?: number,
+    minLevel?: number
 ): Promise<{ message: MessageEmbedOptions; noResults: boolean }> {
     const query: { [key: string]: any } = { bool: { minimum_should_match: 1 } };
     const romanNumberRegex: RegExp = /^((?:x{0,3})(ix|iv|v?i{0,3}))$/i;
@@ -165,6 +166,10 @@ export async function getPetSearchResult(
     let levelFilter: { range: { level: { lte?: number; gte?: number } } } | undefined;
     if (maxLevel !== undefined) {
         levelFilter = { range: { level: { lte: maxLevel } } };
+    }
+    if (minLevel !== undefined) {
+        if (levelFilter) levelFilter.range.level.gte = minLevel;
+        else levelFilter = { range: { level: { gte: minLevel } } };
     }
 
     term = words.map((word) => WORD_ALIASES[word] || word).join(' ');

--- a/src/slashCommands/pet.ts
+++ b/src/slashCommands/pet.ts
@@ -19,6 +19,11 @@ const command: SlashCommandData = {
                 name: 'max-level',
                 description: 'The maximum pet level to return in results. Is 90 by default.',
             },
+            {
+                type: 'INTEGER',
+                name: 'min-level',
+                description: 'The minimum pet level to return in results. Is 0 by default.',
+            },
         ],
     },
 
@@ -26,9 +31,11 @@ const command: SlashCommandData = {
         const searchQuery: string = interaction.options.getString('name', true);
         const maxLevel: number | undefined =
             interaction.options.getInteger('max-level') ?? undefined;
+        const minLevel: number | undefined =
+            interaction.options.getInteger('min-level') ?? undefined;
 
         const petSearchResult: { message: MessageEmbedOptions; noResults: boolean } =
-            await getPetSearchResult(searchQuery, maxLevel);
+            await getPetSearchResult(searchQuery, maxLevel, minLevel);
 
         await interaction.reply({
             embeds: [petSearchResult.message],


### PR DESCRIPTION
- Rewrite pet search query and add aggregations to:
    - Fetch the levels of other variants of the same pet
    - Fetch up to 3 similar search results
- Update pet search to allow minimum level filtering
- Add `minLevel` parameter to slash command, add the following operators to chat command: `<`, `=`, `<=`, `>`, `>=`