### PR TITLE
Fix pet search not working

### DIFF
--- a/src/interactionLogic/search/search.ts
+++ b/src/interactionLogic/search/search.ts
@@ -9,7 +9,7 @@ import { getIndexNames, getVariantAndUnaliasTokens, romanIntToInt } from './util
 export function getSpecificCategoryFilterQuery(
     itemSearchCategory: SearchableItemCategory
 ): { terms: { item_type: SearchableItemCategory[] } } | undefined {
-    if (['weapon', 'accessory', 'item'].includes(itemSearchCategory)) return undefined;
+    if (['weapon', 'accessory', 'item', 'pet'].includes(itemSearchCategory)) return undefined;
 
     let itemTypeFilterItems: SearchableItemCategory[];
 


### PR DESCRIPTION
Fix pet search not working; Return undefined for specific category filter query if item search category is 'pet'.