### PR TITLE
Fix duplicate button name issue

### DIFF
--- a/src/interactionLogic/search/formattedResults.ts
+++ b/src/interactionLogic/search/formattedResults.ts
@@ -146,6 +146,7 @@ export function getButtonListOfSimilarResults({
     maxLevel?: number;
     minLevel?: number;
 }): [MessageActionRowOptions] | [] {
+    const searchResultTitle: string = responseBody.hits.hits[0]._source.full_title;
     const similarResultList = responseBody.aggregations?.similar_results?.filtered?.buckets;
     if (!similarResultList) return [];
 
@@ -153,8 +154,25 @@ export function getButtonListOfSimilarResults({
         .slice(1) // The first element will always be the original search result
         .map(
             (bucket: {
-                items: { top: [{ metrics: { 'full_title.keyword': string; link: string } }] };
-            }) => bucket.items.top[0].metrics['full_title.keyword']
+                items: {
+                    hits: {
+                        hits: [
+                            {
+                                _source: {
+                                    full_title: string;
+                                    item_type: string;
+                                };
+                            }
+                        ];
+                    };
+                };
+            }) => {
+                const similarResultTitle = bucket.items.hits.hits[0]._source['full_title'];
+                const itemType = bucket.items.hits.hits[0]._source['item_type'];
+                return similarResultTitle === searchResultTitle
+                    ? `${similarResultTitle} (${capitalize(itemType)})`
+                    : similarResultTitle;
+            }
         );
     if (!similarResults.length) return [];
 

--- a/src/interactionLogic/search/search.ts
+++ b/src/interactionLogic/search/search.ts
@@ -443,9 +443,10 @@ export async function getItemSearchResult({
                             aggs: {
                                 items: {
                                     // Within each bucket, get only details of pet with max score
-                                    top_metrics: {
-                                        metrics: [{ field: 'full_title.keyword' }],
+                                    top_hits: {
+                                        _source: { includes: ['full_title', 'item_type'] },
                                         sort: { _score: 'desc' },
+                                        size: 1,
                                     },
                                 },
                                 max_score: {


### PR DESCRIPTION
- Display item type next to the item name in the buttons for similar results if they are the same as the current item's title