### PR TITLE
Lower case input weapon element in sort command

### DIFF
--- a/src/slashCommands/sort.ts
+++ b/src/slashCommands/sort.ts
@@ -55,7 +55,7 @@ const command: SlashCommandData = {
 
         const filters = {
             sortExpression,
-            weaponElement,
+            weaponElement: weaponElement?.toLowerCase(),
             minLevel,
             maxLevel,
             charID,


### PR DESCRIPTION
Lower case the input weapon element provided to the sort command to make it case insensitive