### PR TITLE
Add command to compare two items, re-enable pet command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,12 +7,12 @@
         "": {
             "name": "item-bot-df",
             "version": "1.0.0",
-            "license": "ISC",
+            "license": "gpl-3.0",
             "dependencies": {
                 "@elastic/elasticsearch": "^7.16.0",
                 "bufferutil": "^4.0.3",
                 "cheerio": "^1.0.0-rc.10",
-                "discord.js": "^13.15.0",
+                "discord.js": "^13.16.0",
                 "got": "^11.8.2",
                 "install": "^0.13.0",
                 "js-yaml": "^4.1.0",
@@ -436,9 +436,9 @@
             "integrity": "sha512-dvO5M52v7m7Dy96+XUnzXNsQ/0npsYpU6dL205kAtEDueswoz3aU3bh1UMoK4cQmcGtB1YRyLKqp+DXi05lzFg=="
         },
         "node_modules/discord.js": {
-            "version": "13.15.0",
-            "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.15.0.tgz",
-            "integrity": "sha512-60UalCpuCmiufn4jK/uaHjgrwsTNktU1wvjJCX+Wa7e9UtMT5Rqjq1ixPJuT7+yne4hBoAAW9O3ACouJd88uqg==",
+            "version": "13.16.0",
+            "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.16.0.tgz",
+            "integrity": "sha512-bOoCs1Ilojd/UshZVxmEcpxVmHcYOv2fPVZOVq3aFV8xrKLJfaF9mxlvGZ1D1z9aIqf2NkptDr+QndeNuQBTxQ==",
             "dependencies": {
                 "@discordjs/builders": "^0.16.0",
                 "@discordjs/collection": "^0.7.0",
@@ -602,9 +602,9 @@
             }
         },
         "node_modules/http-cache-semantics": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-            "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+            "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
         },
         "node_modules/http2-wrapper": {
             "version": "1.0.3",
@@ -778,9 +778,9 @@
             }
         },
         "node_modules/npm": {
-            "version": "8.15.1",
-            "resolved": "https://registry.npmjs.org/npm/-/npm-8.15.1.tgz",
-            "integrity": "sha512-ZjVMjEn+PqdjpZg+VLMFz5lyzh7tW+SBt+KQzvoQC986U/clE897eg7YR0PLYw6RfjTsoPTuB95xQ8ubn9go6Q==",
+            "version": "8.19.4",
+            "resolved": "https://registry.npmjs.org/npm/-/npm-8.19.4.tgz",
+            "integrity": "sha512-3HANl8i9DKnUA89P4KEgVNN28EjSeDCmvEqbzOAuxCFDzdBZzjUl99zgnGpOUumvW5lvJo2HKcjrsc+tfyv1Hw==",
             "bundleDependencies": [
                 "@isaacs/string-locale-compare",
                 "@npmcli/arborist",
@@ -799,6 +799,7 @@
                 "cli-table3",
                 "columnify",
                 "fastest-levenshtein",
+                "fs-minipass",
                 "glob",
                 "graceful-fs",
                 "hosted-git-info",
@@ -818,6 +819,7 @@
                 "libnpmteam",
                 "libnpmversion",
                 "make-fetch-happen",
+                "minimatch",
                 "minipass",
                 "minipass-pipeline",
                 "mkdirp",
@@ -856,64 +858,66 @@
             ],
             "dependencies": {
                 "@isaacs/string-locale-compare": "^1.1.0",
-                "@npmcli/arborist": "^5.0.4",
+                "@npmcli/arborist": "^5.6.3",
                 "@npmcli/ci-detect": "^2.0.0",
-                "@npmcli/config": "^4.2.0",
+                "@npmcli/config": "^4.2.1",
                 "@npmcli/fs": "^2.1.0",
                 "@npmcli/map-workspaces": "^2.0.3",
                 "@npmcli/package-json": "^2.0.0",
-                "@npmcli/run-script": "^4.1.7",
+                "@npmcli/run-script": "^4.2.1",
                 "abbrev": "~1.1.1",
                 "archy": "~1.0.0",
-                "cacache": "^16.1.1",
+                "cacache": "^16.1.3",
                 "chalk": "^4.1.2",
                 "chownr": "^2.0.0",
                 "cli-columns": "^4.0.0",
                 "cli-table3": "^0.6.2",
                 "columnify": "^1.6.0",
                 "fastest-levenshtein": "^1.0.12",
+                "fs-minipass": "^2.1.0",
                 "glob": "^8.0.1",
                 "graceful-fs": "^4.2.10",
-                "hosted-git-info": "^5.0.0",
-                "ini": "^3.0.0",
+                "hosted-git-info": "^5.2.1",
+                "ini": "^3.0.1",
                 "init-package-json": "^3.0.2",
                 "is-cidr": "^4.0.2",
                 "json-parse-even-better-errors": "^2.3.1",
-                "libnpmaccess": "^6.0.2",
-                "libnpmdiff": "^4.0.2",
-                "libnpmexec": "^4.0.2",
-                "libnpmfund": "^3.0.1",
-                "libnpmhook": "^8.0.2",
-                "libnpmorg": "^4.0.2",
-                "libnpmpack": "^4.0.2",
-                "libnpmpublish": "^6.0.2",
-                "libnpmsearch": "^5.0.2",
-                "libnpmteam": "^4.0.2",
-                "libnpmversion": "^3.0.1",
+                "libnpmaccess": "^6.0.4",
+                "libnpmdiff": "^4.0.5",
+                "libnpmexec": "^4.0.14",
+                "libnpmfund": "^3.0.5",
+                "libnpmhook": "^8.0.4",
+                "libnpmorg": "^4.0.4",
+                "libnpmpack": "^4.1.3",
+                "libnpmpublish": "^6.0.5",
+                "libnpmsearch": "^5.0.4",
+                "libnpmteam": "^4.0.4",
+                "libnpmversion": "^3.0.7",
                 "make-fetch-happen": "^10.2.0",
+                "minimatch": "^5.1.0",
                 "minipass": "^3.1.6",
                 "minipass-pipeline": "^1.2.4",
                 "mkdirp": "^1.0.4",
                 "mkdirp-infer-owner": "^2.0.0",
                 "ms": "^2.1.2",
-                "node-gyp": "^9.0.0",
-                "nopt": "^5.0.0",
+                "node-gyp": "^9.1.0",
+                "nopt": "^6.0.0",
                 "npm-audit-report": "^3.0.0",
                 "npm-install-checks": "^5.0.0",
                 "npm-package-arg": "^9.1.0",
-                "npm-pick-manifest": "^7.0.1",
+                "npm-pick-manifest": "^7.0.2",
                 "npm-profile": "^6.2.0",
-                "npm-registry-fetch": "^13.3.0",
+                "npm-registry-fetch": "^13.3.1",
                 "npm-user-validate": "^1.0.1",
                 "npmlog": "^6.0.2",
                 "opener": "^1.5.2",
                 "p-map": "^4.0.0",
-                "pacote": "^13.6.1",
+                "pacote": "^13.6.2",
                 "parse-conflict-json": "^2.0.2",
                 "proc-log": "^2.0.1",
                 "qrcode-terminal": "^0.12.0",
                 "read": "~1.0.7",
-                "read-package-json": "^5.0.1",
+                "read-package-json": "^5.0.2",
                 "read-package-json-fast": "^2.0.3",
                 "readdir-scoped-modules": "^1.1.0",
                 "rimraf": "^3.0.2",
@@ -932,7 +936,7 @@
                 "npx": "bin/npx-cli.js"
             },
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16"
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
             }
         },
         "node_modules/npm/node_modules/@colors/colors": {
@@ -955,7 +959,7 @@
             "license": "ISC"
         },
         "node_modules/npm/node_modules/@npmcli/arborist": {
-            "version": "5.3.1",
+            "version": "5.6.3",
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -967,18 +971,21 @@
                 "@npmcli/name-from-folder": "^1.0.1",
                 "@npmcli/node-gyp": "^2.0.0",
                 "@npmcli/package-json": "^2.0.0",
+                "@npmcli/query": "^1.2.0",
                 "@npmcli/run-script": "^4.1.3",
-                "bin-links": "^3.0.0",
-                "cacache": "^16.0.6",
+                "bin-links": "^3.0.3",
+                "cacache": "^16.1.3",
                 "common-ancestor-path": "^1.0.1",
+                "hosted-git-info": "^5.2.1",
                 "json-parse-even-better-errors": "^2.3.1",
                 "json-stringify-nice": "^1.1.4",
+                "minimatch": "^5.1.0",
                 "mkdirp": "^1.0.4",
                 "mkdirp-infer-owner": "^2.0.0",
-                "nopt": "^5.0.0",
+                "nopt": "^6.0.0",
                 "npm-install-checks": "^5.0.0",
                 "npm-package-arg": "^9.0.0",
-                "npm-pick-manifest": "^7.0.0",
+                "npm-pick-manifest": "^7.0.2",
                 "npm-registry-fetch": "^13.0.0",
                 "npmlog": "^6.0.2",
                 "pacote": "^13.6.1",
@@ -1010,14 +1017,14 @@
             }
         },
         "node_modules/npm/node_modules/@npmcli/config": {
-            "version": "4.2.0",
+            "version": "4.2.2",
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
                 "@npmcli/map-workspaces": "^2.0.2",
                 "ini": "^3.0.0",
                 "mkdirp-infer-owner": "^2.0.0",
-                "nopt": "^5.0.0",
+                "nopt": "^6.0.0",
                 "proc-log": "^2.0.0",
                 "read-package-json-fast": "^2.0.3",
                 "semver": "^7.3.5",
@@ -1039,7 +1046,7 @@
             }
         },
         "node_modules/npm/node_modules/@npmcli/fs": {
-            "version": "2.1.0",
+            "version": "2.1.2",
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -1051,7 +1058,7 @@
             }
         },
         "node_modules/npm/node_modules/@npmcli/git": {
-            "version": "3.0.1",
+            "version": "3.0.2",
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -1084,8 +1091,16 @@
                 "node": ">= 10"
             }
         },
+        "node_modules/npm/node_modules/@npmcli/installed-package-contents/node_modules/npm-bundled": {
+            "version": "1.1.2",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "npm-normalize-package-bin": "^1.0.1"
+            }
+        },
         "node_modules/npm/node_modules/@npmcli/map-workspaces": {
-            "version": "2.0.3",
+            "version": "2.0.4",
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -1113,7 +1128,7 @@
             }
         },
         "node_modules/npm/node_modules/@npmcli/move-file": {
-            "version": "2.0.0",
+            "version": "2.0.1",
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -1159,8 +1174,21 @@
                 "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
             }
         },
+        "node_modules/npm/node_modules/@npmcli/query": {
+            "version": "1.2.0",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "npm-package-arg": "^9.1.0",
+                "postcss-selector-parser": "^6.0.10",
+                "semver": "^7.3.7"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
         "node_modules/npm/node_modules/@npmcli/run-script": {
-            "version": "4.1.7",
+            "version": "4.2.1",
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -1256,7 +1284,7 @@
             "license": "MIT"
         },
         "node_modules/npm/node_modules/are-we-there-yet": {
-            "version": "3.0.0",
+            "version": "3.0.1",
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -1264,7 +1292,7 @@
                 "readable-stream": "^3.6.0"
             },
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16"
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
             }
         },
         "node_modules/npm/node_modules/asap": {
@@ -1278,17 +1306,25 @@
             "license": "MIT"
         },
         "node_modules/npm/node_modules/bin-links": {
-            "version": "3.0.1",
+            "version": "3.0.3",
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
                 "cmd-shim": "^5.0.0",
                 "mkdirp-infer-owner": "^2.0.0",
-                "npm-normalize-package-bin": "^1.0.0",
+                "npm-normalize-package-bin": "^2.0.0",
                 "read-cmd-shim": "^3.0.0",
                 "rimraf": "^3.0.0",
                 "write-file-atomic": "^4.0.0"
             },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/bin-links/node_modules/npm-normalize-package-bin": {
+            "version": "2.0.0",
+            "inBundle": true,
+            "license": "ISC",
             "engines": {
                 "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
             }
@@ -1318,7 +1354,7 @@
             }
         },
         "node_modules/npm/node_modules/cacache": {
-            "version": "16.1.1",
+            "version": "16.1.3",
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -1339,7 +1375,7 @@
                 "rimraf": "^3.0.2",
                 "ssri": "^9.0.0",
                 "tar": "^6.1.11",
-                "unique-filename": "^1.1.1"
+                "unique-filename": "^2.0.0"
             },
             "engines": {
                 "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
@@ -1483,6 +1519,17 @@
             "inBundle": true,
             "license": "ISC"
         },
+        "node_modules/npm/node_modules/cssesc": {
+            "version": "3.0.0",
+            "inBundle": true,
+            "license": "MIT",
+            "bin": {
+                "cssesc": "bin/cssesc"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/npm/node_modules/debug": {
             "version": "4.3.4",
             "inBundle": true,
@@ -1543,7 +1590,7 @@
             }
         },
         "node_modules/npm/node_modules/diff": {
-            "version": "5.0.0",
+            "version": "5.1.0",
             "inBundle": true,
             "license": "BSD-3-Clause",
             "engines": {
@@ -1669,18 +1716,18 @@
             "license": "ISC"
         },
         "node_modules/npm/node_modules/hosted-git-info": {
-            "version": "5.0.0",
+            "version": "5.2.1",
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^7.5.1"
             },
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16"
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
             }
         },
         "node_modules/npm/node_modules/http-cache-semantics": {
-            "version": "4.1.0",
+            "version": "4.1.1",
             "inBundle": true,
             "license": "BSD-2-Clause"
         },
@@ -1776,7 +1823,7 @@
             "license": "ISC"
         },
         "node_modules/npm/node_modules/ini": {
-            "version": "3.0.0",
+            "version": "3.0.1",
             "inBundle": true,
             "license": "ISC",
             "engines": {
@@ -1801,7 +1848,7 @@
             }
         },
         "node_modules/npm/node_modules/ip": {
-            "version": "1.1.8",
+            "version": "2.0.0",
             "inBundle": true,
             "license": "MIT"
         },
@@ -1825,7 +1872,7 @@
             }
         },
         "node_modules/npm/node_modules/is-core-module": {
-            "version": "2.9.0",
+            "version": "2.10.0",
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -1875,17 +1922,17 @@
             "license": "MIT"
         },
         "node_modules/npm/node_modules/just-diff": {
-            "version": "5.0.3",
+            "version": "5.1.1",
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/just-diff-apply": {
-            "version": "5.3.1",
+            "version": "5.4.1",
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/libnpmaccess": {
-            "version": "6.0.3",
+            "version": "6.0.4",
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -1899,14 +1946,14 @@
             }
         },
         "node_modules/npm/node_modules/libnpmdiff": {
-            "version": "4.0.4",
+            "version": "4.0.5",
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
                 "@npmcli/disparity-colors": "^2.0.0",
                 "@npmcli/installed-package-contents": "^1.0.7",
                 "binary-extensions": "^2.2.0",
-                "diff": "^5.0.0",
+                "diff": "^5.1.0",
                 "minimatch": "^5.0.1",
                 "npm-package-arg": "^9.0.1",
                 "pacote": "^13.6.1",
@@ -1917,13 +1964,14 @@
             }
         },
         "node_modules/npm/node_modules/libnpmexec": {
-            "version": "4.0.8",
+            "version": "4.0.14",
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/arborist": "^5.0.0",
+                "@npmcli/arborist": "^5.6.3",
                 "@npmcli/ci-detect": "^2.0.0",
-                "@npmcli/run-script": "^4.1.3",
+                "@npmcli/fs": "^2.1.1",
+                "@npmcli/run-script": "^4.2.0",
                 "chalk": "^4.1.0",
                 "mkdirp-infer-owner": "^2.0.0",
                 "npm-package-arg": "^9.0.1",
@@ -1932,6 +1980,7 @@
                 "proc-log": "^2.0.0",
                 "read": "^1.0.7",
                 "read-package-json-fast": "^2.0.2",
+                "semver": "^7.3.7",
                 "walk-up-path": "^1.0.0"
             },
             "engines": {
@@ -1939,18 +1988,18 @@
             }
         },
         "node_modules/npm/node_modules/libnpmfund": {
-            "version": "3.0.2",
+            "version": "3.0.5",
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/arborist": "^5.0.0"
+                "@npmcli/arborist": "^5.6.3"
             },
             "engines": {
                 "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
             }
         },
         "node_modules/npm/node_modules/libnpmhook": {
-            "version": "8.0.3",
+            "version": "8.0.4",
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -1962,7 +2011,7 @@
             }
         },
         "node_modules/npm/node_modules/libnpmorg": {
-            "version": "4.0.3",
+            "version": "4.0.4",
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -1974,7 +2023,7 @@
             }
         },
         "node_modules/npm/node_modules/libnpmpack": {
-            "version": "4.1.2",
+            "version": "4.1.3",
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -1987,7 +2036,7 @@
             }
         },
         "node_modules/npm/node_modules/libnpmpublish": {
-            "version": "6.0.4",
+            "version": "6.0.5",
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -2002,7 +2051,7 @@
             }
         },
         "node_modules/npm/node_modules/libnpmsearch": {
-            "version": "5.0.3",
+            "version": "5.0.4",
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -2013,7 +2062,7 @@
             }
         },
         "node_modules/npm/node_modules/libnpmteam": {
-            "version": "4.0.3",
+            "version": "4.0.4",
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -2025,7 +2074,7 @@
             }
         },
         "node_modules/npm/node_modules/libnpmversion": {
-            "version": "3.0.6",
+            "version": "3.0.7",
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -2040,7 +2089,7 @@
             }
         },
         "node_modules/npm/node_modules/lru-cache": {
-            "version": "7.12.0",
+            "version": "7.13.2",
             "inBundle": true,
             "license": "ISC",
             "engines": {
@@ -2048,7 +2097,7 @@
             }
         },
         "node_modules/npm/node_modules/make-fetch-happen": {
-            "version": "10.2.0",
+            "version": "10.2.1",
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -2107,7 +2156,7 @@
             }
         },
         "node_modules/npm/node_modules/minipass-fetch": {
-            "version": "2.1.0",
+            "version": "2.1.1",
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -2219,7 +2268,7 @@
             }
         },
         "node_modules/npm/node_modules/node-gyp": {
-            "version": "9.0.0",
+            "version": "9.1.0",
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -2280,7 +2329,7 @@
                 "node": "*"
             }
         },
-        "node_modules/npm/node_modules/nopt": {
+        "node_modules/npm/node_modules/node-gyp/node_modules/nopt": {
             "version": "5.0.0",
             "inBundle": true,
             "license": "ISC",
@@ -2294,8 +2343,22 @@
                 "node": ">=6"
             }
         },
+        "node_modules/npm/node_modules/nopt": {
+            "version": "6.0.0",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "abbrev": "^1.0.0"
+            },
+            "bin": {
+                "nopt": "bin/nopt.js"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
         "node_modules/npm/node_modules/normalize-package-data": {
-            "version": "4.0.0",
+            "version": "4.0.1",
             "inBundle": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -2305,7 +2368,7 @@
                 "validate-npm-package-license": "^3.0.4"
             },
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16"
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
             }
         },
         "node_modules/npm/node_modules/npm-audit-report": {
@@ -2320,11 +2383,22 @@
             }
         },
         "node_modules/npm/node_modules/npm-bundled": {
-            "version": "1.1.2",
+            "version": "2.0.1",
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "npm-normalize-package-bin": "^1.0.1"
+                "npm-normalize-package-bin": "^2.0.0"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/npm-bundled/node_modules/npm-normalize-package-bin": {
+            "version": "2.0.0",
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
             }
         },
         "node_modules/npm/node_modules/npm-install-checks": {
@@ -2358,14 +2432,14 @@
             }
         },
         "node_modules/npm/node_modules/npm-packlist": {
-            "version": "5.1.1",
+            "version": "5.1.3",
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
                 "glob": "^8.0.1",
                 "ignore-walk": "^5.0.1",
-                "npm-bundled": "^1.1.2",
-                "npm-normalize-package-bin": "^1.0.1"
+                "npm-bundled": "^2.0.0",
+                "npm-normalize-package-bin": "^2.0.0"
             },
             "bin": {
                 "npm-packlist": "bin/index.js"
@@ -2374,13 +2448,21 @@
                 "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
             }
         },
+        "node_modules/npm/node_modules/npm-packlist/node_modules/npm-normalize-package-bin": {
+            "version": "2.0.0",
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
         "node_modules/npm/node_modules/npm-pick-manifest": {
-            "version": "7.0.1",
+            "version": "7.0.2",
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
                 "npm-install-checks": "^5.0.0",
-                "npm-normalize-package-bin": "^1.0.1",
+                "npm-normalize-package-bin": "^2.0.0",
                 "npm-package-arg": "^9.0.0",
                 "semver": "^7.3.5"
             },
@@ -2388,8 +2470,16 @@
                 "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
             }
         },
+        "node_modules/npm/node_modules/npm-pick-manifest/node_modules/npm-normalize-package-bin": {
+            "version": "2.0.0",
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
         "node_modules/npm/node_modules/npm-profile": {
-            "version": "6.2.0",
+            "version": "6.2.1",
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -2401,7 +2491,7 @@
             }
         },
         "node_modules/npm/node_modules/npm-registry-fetch": {
-            "version": "13.3.0",
+            "version": "13.3.1",
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -2467,7 +2557,7 @@
             }
         },
         "node_modules/npm/node_modules/pacote": {
-            "version": "13.6.1",
+            "version": "13.6.2",
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -2519,6 +2609,18 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/npm/node_modules/postcss-selector-parser": {
+            "version": "6.0.10",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "cssesc": "^3.0.0",
+                "util-deprecate": "^1.0.2"
+            },
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/npm/node_modules/proc-log": {
@@ -2597,14 +2699,14 @@
             }
         },
         "node_modules/npm/node_modules/read-package-json": {
-            "version": "5.0.1",
+            "version": "5.0.2",
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
                 "glob": "^8.0.1",
                 "json-parse-even-better-errors": "^2.3.1",
                 "normalize-package-data": "^4.0.0",
-                "npm-normalize-package-bin": "^1.0.1"
+                "npm-normalize-package-bin": "^2.0.0"
             },
             "engines": {
                 "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
@@ -2620,6 +2722,14 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/npm/node_modules/read-package-json/node_modules/npm-normalize-package-bin": {
+            "version": "2.0.0",
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
             }
         },
         "node_modules/npm/node_modules/readable-stream": {
@@ -2777,11 +2887,11 @@
             }
         },
         "node_modules/npm/node_modules/socks": {
-            "version": "2.6.2",
+            "version": "2.7.0",
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
-                "ip": "^1.1.5",
+                "ip": "^2.0.0",
                 "smart-buffer": "^4.2.0"
             },
             "engines": {
@@ -2919,19 +3029,25 @@
             }
         },
         "node_modules/npm/node_modules/unique-filename": {
-            "version": "1.1.1",
+            "version": "2.0.1",
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "unique-slug": "^2.0.0"
+                "unique-slug": "^3.0.0"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
             }
         },
         "node_modules/npm/node_modules/unique-slug": {
-            "version": "2.0.2",
+            "version": "3.0.0",
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
                 "imurmurhash": "^0.1.4"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
             }
         },
         "node_modules/npm/node_modules/util-deprecate": {
@@ -3000,7 +3116,7 @@
             "license": "ISC"
         },
         "node_modules/npm/node_modules/write-file-atomic": {
-            "version": "4.0.1",
+            "version": "4.0.2",
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -3008,7 +3124,7 @@
                 "signal-exit": "^3.0.7"
             },
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16"
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
             }
         },
         "node_modules/npm/node_modules/yallist": {
@@ -3583,9 +3699,9 @@
             "integrity": "sha512-dvO5M52v7m7Dy96+XUnzXNsQ/0npsYpU6dL205kAtEDueswoz3aU3bh1UMoK4cQmcGtB1YRyLKqp+DXi05lzFg=="
         },
         "discord.js": {
-            "version": "13.15.0",
-            "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.15.0.tgz",
-            "integrity": "sha512-60UalCpuCmiufn4jK/uaHjgrwsTNktU1wvjJCX+Wa7e9UtMT5Rqjq1ixPJuT7+yne4hBoAAW9O3ACouJd88uqg==",
+            "version": "13.16.0",
+            "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.16.0.tgz",
+            "integrity": "sha512-bOoCs1Ilojd/UshZVxmEcpxVmHcYOv2fPVZOVq3aFV8xrKLJfaF9mxlvGZ1D1z9aIqf2NkptDr+QndeNuQBTxQ==",
             "requires": {
                 "@discordjs/builders": "^0.16.0",
                 "@discordjs/collection": "^0.7.0",
@@ -3702,9 +3818,9 @@
             }
         },
         "http-cache-semantics": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-            "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+            "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
         },
         "http2-wrapper": {
             "version": "1.0.3",
@@ -3827,69 +3943,71 @@
             "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A=="
         },
         "npm": {
-            "version": "8.15.1",
-            "resolved": "https://registry.npmjs.org/npm/-/npm-8.15.1.tgz",
-            "integrity": "sha512-ZjVMjEn+PqdjpZg+VLMFz5lyzh7tW+SBt+KQzvoQC986U/clE897eg7YR0PLYw6RfjTsoPTuB95xQ8ubn9go6Q==",
+            "version": "8.19.4",
+            "resolved": "https://registry.npmjs.org/npm/-/npm-8.19.4.tgz",
+            "integrity": "sha512-3HANl8i9DKnUA89P4KEgVNN28EjSeDCmvEqbzOAuxCFDzdBZzjUl99zgnGpOUumvW5lvJo2HKcjrsc+tfyv1Hw==",
             "requires": {
                 "@isaacs/string-locale-compare": "^1.1.0",
-                "@npmcli/arborist": "^5.0.4",
+                "@npmcli/arborist": "^5.6.3",
                 "@npmcli/ci-detect": "^2.0.0",
-                "@npmcli/config": "^4.2.0",
+                "@npmcli/config": "^4.2.1",
                 "@npmcli/fs": "^2.1.0",
                 "@npmcli/map-workspaces": "^2.0.3",
                 "@npmcli/package-json": "^2.0.0",
-                "@npmcli/run-script": "^4.1.7",
+                "@npmcli/run-script": "^4.2.1",
                 "abbrev": "~1.1.1",
                 "archy": "~1.0.0",
-                "cacache": "^16.1.1",
+                "cacache": "^16.1.3",
                 "chalk": "^4.1.2",
                 "chownr": "^2.0.0",
                 "cli-columns": "^4.0.0",
                 "cli-table3": "^0.6.2",
                 "columnify": "^1.6.0",
                 "fastest-levenshtein": "^1.0.12",
+                "fs-minipass": "^2.1.0",
                 "glob": "^8.0.1",
                 "graceful-fs": "^4.2.10",
-                "hosted-git-info": "^5.0.0",
-                "ini": "^3.0.0",
+                "hosted-git-info": "^5.2.1",
+                "ini": "^3.0.1",
                 "init-package-json": "^3.0.2",
                 "is-cidr": "^4.0.2",
                 "json-parse-even-better-errors": "^2.3.1",
-                "libnpmaccess": "^6.0.2",
-                "libnpmdiff": "^4.0.2",
-                "libnpmexec": "^4.0.2",
-                "libnpmfund": "^3.0.1",
-                "libnpmhook": "^8.0.2",
-                "libnpmorg": "^4.0.2",
-                "libnpmpack": "^4.0.2",
-                "libnpmpublish": "^6.0.2",
-                "libnpmsearch": "^5.0.2",
-                "libnpmteam": "^4.0.2",
-                "libnpmversion": "^3.0.1",
+                "libnpmaccess": "^6.0.4",
+                "libnpmdiff": "^4.0.5",
+                "libnpmexec": "^4.0.14",
+                "libnpmfund": "^3.0.5",
+                "libnpmhook": "^8.0.4",
+                "libnpmorg": "^4.0.4",
+                "libnpmpack": "^4.1.3",
+                "libnpmpublish": "^6.0.5",
+                "libnpmsearch": "^5.0.4",
+                "libnpmteam": "^4.0.4",
+                "libnpmversion": "^3.0.7",
                 "make-fetch-happen": "^10.2.0",
+                "minimatch": "^5.1.0",
                 "minipass": "^3.1.6",
                 "minipass-pipeline": "^1.2.4",
                 "mkdirp": "^1.0.4",
                 "mkdirp-infer-owner": "^2.0.0",
                 "ms": "^2.1.2",
-                "node-gyp": "^9.0.0",
-                "nopt": "^5.0.0",
+                "node-gyp": "^9.1.0",
+                "nopt": "^6.0.0",
                 "npm-audit-report": "^3.0.0",
                 "npm-install-checks": "^5.0.0",
                 "npm-package-arg": "^9.1.0",
-                "npm-pick-manifest": "^7.0.1",
+                "npm-pick-manifest": "^7.0.2",
                 "npm-profile": "^6.2.0",
-                "npm-registry-fetch": "^13.3.0",
+                "npm-registry-fetch": "^13.3.1",
                 "npm-user-validate": "^1.0.1",
                 "npmlog": "^6.0.2",
                 "opener": "^1.5.2",
                 "p-map": "^4.0.0",
-                "pacote": "^13.6.1",
+                "pacote": "^13.6.2",
                 "parse-conflict-json": "^2.0.2",
                 "proc-log": "^2.0.1",
                 "qrcode-terminal": "^0.12.0",
                 "read": "~1.0.7",
-                "read-package-json": "^5.0.1",
+                "read-package-json": "^5.0.2",
                 "read-package-json-fast": "^2.0.3",
                 "readdir-scoped-modules": "^1.1.0",
                 "rimraf": "^3.0.2",
@@ -3918,7 +4036,7 @@
                     "bundled": true
                 },
                 "@npmcli/arborist": {
-                    "version": "5.3.1",
+                    "version": "5.6.3",
                     "bundled": true,
                     "requires": {
                         "@isaacs/string-locale-compare": "^1.1.0",
@@ -3929,18 +4047,21 @@
                         "@npmcli/name-from-folder": "^1.0.1",
                         "@npmcli/node-gyp": "^2.0.0",
                         "@npmcli/package-json": "^2.0.0",
+                        "@npmcli/query": "^1.2.0",
                         "@npmcli/run-script": "^4.1.3",
-                        "bin-links": "^3.0.0",
-                        "cacache": "^16.0.6",
+                        "bin-links": "^3.0.3",
+                        "cacache": "^16.1.3",
                         "common-ancestor-path": "^1.0.1",
+                        "hosted-git-info": "^5.2.1",
                         "json-parse-even-better-errors": "^2.3.1",
                         "json-stringify-nice": "^1.1.4",
+                        "minimatch": "^5.1.0",
                         "mkdirp": "^1.0.4",
                         "mkdirp-infer-owner": "^2.0.0",
-                        "nopt": "^5.0.0",
+                        "nopt": "^6.0.0",
                         "npm-install-checks": "^5.0.0",
                         "npm-package-arg": "^9.0.0",
-                        "npm-pick-manifest": "^7.0.0",
+                        "npm-pick-manifest": "^7.0.2",
                         "npm-registry-fetch": "^13.0.0",
                         "npmlog": "^6.0.2",
                         "pacote": "^13.6.1",
@@ -3962,13 +4083,13 @@
                     "bundled": true
                 },
                 "@npmcli/config": {
-                    "version": "4.2.0",
+                    "version": "4.2.2",
                     "bundled": true,
                     "requires": {
                         "@npmcli/map-workspaces": "^2.0.2",
                         "ini": "^3.0.0",
                         "mkdirp-infer-owner": "^2.0.0",
-                        "nopt": "^5.0.0",
+                        "nopt": "^6.0.0",
                         "proc-log": "^2.0.0",
                         "read-package-json-fast": "^2.0.3",
                         "semver": "^7.3.5",
@@ -3983,7 +4104,7 @@
                     }
                 },
                 "@npmcli/fs": {
-                    "version": "2.1.0",
+                    "version": "2.1.2",
                     "bundled": true,
                     "requires": {
                         "@gar/promisify": "^1.1.3",
@@ -3991,7 +4112,7 @@
                     }
                 },
                 "@npmcli/git": {
-                    "version": "3.0.1",
+                    "version": "3.0.2",
                     "bundled": true,
                     "requires": {
                         "@npmcli/promise-spawn": "^3.0.0",
@@ -4011,10 +4132,19 @@
                     "requires": {
                         "npm-bundled": "^1.1.1",
                         "npm-normalize-package-bin": "^1.0.1"
+                    },
+                    "dependencies": {
+                        "npm-bundled": {
+                            "version": "1.1.2",
+                            "bundled": true,
+                            "requires": {
+                                "npm-normalize-package-bin": "^1.0.1"
+                            }
+                        }
                     }
                 },
                 "@npmcli/map-workspaces": {
-                    "version": "2.0.3",
+                    "version": "2.0.4",
                     "bundled": true,
                     "requires": {
                         "@npmcli/name-from-folder": "^1.0.1",
@@ -4034,7 +4164,7 @@
                     }
                 },
                 "@npmcli/move-file": {
-                    "version": "2.0.0",
+                    "version": "2.0.1",
                     "bundled": true,
                     "requires": {
                         "mkdirp": "^1.0.4",
@@ -4063,8 +4193,17 @@
                         "infer-owner": "^1.0.4"
                     }
                 },
+                "@npmcli/query": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "requires": {
+                        "npm-package-arg": "^9.1.0",
+                        "postcss-selector-parser": "^6.0.10",
+                        "semver": "^7.3.7"
+                    }
+                },
                 "@npmcli/run-script": {
-                    "version": "4.1.7",
+                    "version": "4.2.1",
                     "bundled": true,
                     "requires": {
                         "@npmcli/node-gyp": "^2.0.0",
@@ -4126,7 +4265,7 @@
                     "bundled": true
                 },
                 "are-we-there-yet": {
-                    "version": "3.0.0",
+                    "version": "3.0.1",
                     "bundled": true,
                     "requires": {
                         "delegates": "^1.0.0",
@@ -4142,15 +4281,21 @@
                     "bundled": true
                 },
                 "bin-links": {
-                    "version": "3.0.1",
+                    "version": "3.0.3",
                     "bundled": true,
                     "requires": {
                         "cmd-shim": "^5.0.0",
                         "mkdirp-infer-owner": "^2.0.0",
-                        "npm-normalize-package-bin": "^1.0.0",
+                        "npm-normalize-package-bin": "^2.0.0",
                         "read-cmd-shim": "^3.0.0",
                         "rimraf": "^3.0.0",
                         "write-file-atomic": "^4.0.0"
+                    },
+                    "dependencies": {
+                        "npm-normalize-package-bin": {
+                            "version": "2.0.0",
+                            "bundled": true
+                        }
                     }
                 },
                 "binary-extensions": {
@@ -4172,7 +4317,7 @@
                     }
                 },
                 "cacache": {
-                    "version": "16.1.1",
+                    "version": "16.1.3",
                     "bundled": true,
                     "requires": {
                         "@npmcli/fs": "^2.1.0",
@@ -4192,7 +4337,7 @@
                         "rimraf": "^3.0.2",
                         "ssri": "^9.0.0",
                         "tar": "^6.1.11",
-                        "unique-filename": "^1.1.1"
+                        "unique-filename": "^2.0.0"
                     }
                 },
                 "chalk": {
@@ -4280,6 +4425,10 @@
                     "version": "1.1.0",
                     "bundled": true
                 },
+                "cssesc": {
+                    "version": "3.0.0",
+                    "bundled": true
+                },
                 "debug": {
                     "version": "4.3.4",
                     "bundled": true,
@@ -4321,7 +4470,7 @@
                     }
                 },
                 "diff": {
-                    "version": "5.0.0",
+                    "version": "5.1.0",
                     "bundled": true
                 },
                 "emoji-regex": {
@@ -4408,14 +4557,14 @@
                     "bundled": true
                 },
                 "hosted-git-info": {
-                    "version": "5.0.0",
+                    "version": "5.2.1",
                     "bundled": true,
                     "requires": {
                         "lru-cache": "^7.5.1"
                     }
                 },
                 "http-cache-semantics": {
-                    "version": "4.1.0",
+                    "version": "4.1.1",
                     "bundled": true
                 },
                 "http-proxy-agent": {
@@ -4482,7 +4631,7 @@
                     "bundled": true
                 },
                 "ini": {
-                    "version": "3.0.0",
+                    "version": "3.0.1",
                     "bundled": true
                 },
                 "init-package-json": {
@@ -4499,7 +4648,7 @@
                     }
                 },
                 "ip": {
-                    "version": "1.1.8",
+                    "version": "2.0.0",
                     "bundled": true
                 },
                 "ip-regex": {
@@ -4514,7 +4663,7 @@
                     }
                 },
                 "is-core-module": {
-                    "version": "2.9.0",
+                    "version": "2.10.0",
                     "bundled": true,
                     "requires": {
                         "has": "^1.0.3"
@@ -4545,15 +4694,15 @@
                     "bundled": true
                 },
                 "just-diff": {
-                    "version": "5.0.3",
+                    "version": "5.1.1",
                     "bundled": true
                 },
                 "just-diff-apply": {
-                    "version": "5.3.1",
+                    "version": "5.4.1",
                     "bundled": true
                 },
                 "libnpmaccess": {
-                    "version": "6.0.3",
+                    "version": "6.0.4",
                     "bundled": true,
                     "requires": {
                         "aproba": "^2.0.0",
@@ -4563,13 +4712,13 @@
                     }
                 },
                 "libnpmdiff": {
-                    "version": "4.0.4",
+                    "version": "4.0.5",
                     "bundled": true,
                     "requires": {
                         "@npmcli/disparity-colors": "^2.0.0",
                         "@npmcli/installed-package-contents": "^1.0.7",
                         "binary-extensions": "^2.2.0",
-                        "diff": "^5.0.0",
+                        "diff": "^5.1.0",
                         "minimatch": "^5.0.1",
                         "npm-package-arg": "^9.0.1",
                         "pacote": "^13.6.1",
@@ -4577,12 +4726,13 @@
                     }
                 },
                 "libnpmexec": {
-                    "version": "4.0.8",
+                    "version": "4.0.14",
                     "bundled": true,
                     "requires": {
-                        "@npmcli/arborist": "^5.0.0",
+                        "@npmcli/arborist": "^5.6.3",
                         "@npmcli/ci-detect": "^2.0.0",
-                        "@npmcli/run-script": "^4.1.3",
+                        "@npmcli/fs": "^2.1.1",
+                        "@npmcli/run-script": "^4.2.0",
                         "chalk": "^4.1.0",
                         "mkdirp-infer-owner": "^2.0.0",
                         "npm-package-arg": "^9.0.1",
@@ -4591,18 +4741,19 @@
                         "proc-log": "^2.0.0",
                         "read": "^1.0.7",
                         "read-package-json-fast": "^2.0.2",
+                        "semver": "^7.3.7",
                         "walk-up-path": "^1.0.0"
                     }
                 },
                 "libnpmfund": {
-                    "version": "3.0.2",
+                    "version": "3.0.5",
                     "bundled": true,
                     "requires": {
-                        "@npmcli/arborist": "^5.0.0"
+                        "@npmcli/arborist": "^5.6.3"
                     }
                 },
                 "libnpmhook": {
-                    "version": "8.0.3",
+                    "version": "8.0.4",
                     "bundled": true,
                     "requires": {
                         "aproba": "^2.0.0",
@@ -4610,7 +4761,7 @@
                     }
                 },
                 "libnpmorg": {
-                    "version": "4.0.3",
+                    "version": "4.0.4",
                     "bundled": true,
                     "requires": {
                         "aproba": "^2.0.0",
@@ -4618,7 +4769,7 @@
                     }
                 },
                 "libnpmpack": {
-                    "version": "4.1.2",
+                    "version": "4.1.3",
                     "bundled": true,
                     "requires": {
                         "@npmcli/run-script": "^4.1.3",
@@ -4627,7 +4778,7 @@
                     }
                 },
                 "libnpmpublish": {
-                    "version": "6.0.4",
+                    "version": "6.0.5",
                     "bundled": true,
                     "requires": {
                         "normalize-package-data": "^4.0.0",
@@ -4638,14 +4789,14 @@
                     }
                 },
                 "libnpmsearch": {
-                    "version": "5.0.3",
+                    "version": "5.0.4",
                     "bundled": true,
                     "requires": {
                         "npm-registry-fetch": "^13.0.0"
                     }
                 },
                 "libnpmteam": {
-                    "version": "4.0.3",
+                    "version": "4.0.4",
                     "bundled": true,
                     "requires": {
                         "aproba": "^2.0.0",
@@ -4653,7 +4804,7 @@
                     }
                 },
                 "libnpmversion": {
-                    "version": "3.0.6",
+                    "version": "3.0.7",
                     "bundled": true,
                     "requires": {
                         "@npmcli/git": "^3.0.0",
@@ -4664,11 +4815,11 @@
                     }
                 },
                 "lru-cache": {
-                    "version": "7.12.0",
+                    "version": "7.13.2",
                     "bundled": true
                 },
                 "make-fetch-happen": {
-                    "version": "10.2.0",
+                    "version": "10.2.1",
                     "bundled": true,
                     "requires": {
                         "agentkeepalive": "^4.2.1",
@@ -4711,7 +4862,7 @@
                     }
                 },
                 "minipass-fetch": {
-                    "version": "2.1.0",
+                    "version": "2.1.1",
                     "bundled": true,
                     "requires": {
                         "encoding": "^0.1.13",
@@ -4783,7 +4934,7 @@
                     "bundled": true
                 },
                 "node-gyp": {
-                    "version": "9.0.0",
+                    "version": "9.1.0",
                     "bundled": true,
                     "requires": {
                         "env-paths": "^2.2.0",
@@ -4824,18 +4975,25 @@
                             "requires": {
                                 "brace-expansion": "^1.1.7"
                             }
+                        },
+                        "nopt": {
+                            "version": "5.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "abbrev": "1"
+                            }
                         }
                     }
                 },
                 "nopt": {
-                    "version": "5.0.0",
+                    "version": "6.0.0",
                     "bundled": true,
                     "requires": {
-                        "abbrev": "1"
+                        "abbrev": "^1.0.0"
                     }
                 },
                 "normalize-package-data": {
-                    "version": "4.0.0",
+                    "version": "4.0.1",
                     "bundled": true,
                     "requires": {
                         "hosted-git-info": "^5.0.0",
@@ -4852,10 +5010,16 @@
                     }
                 },
                 "npm-bundled": {
-                    "version": "1.1.2",
+                    "version": "2.0.1",
                     "bundled": true,
                     "requires": {
-                        "npm-normalize-package-bin": "^1.0.1"
+                        "npm-normalize-package-bin": "^2.0.0"
+                    },
+                    "dependencies": {
+                        "npm-normalize-package-bin": {
+                            "version": "2.0.0",
+                            "bundled": true
+                        }
                     }
                 },
                 "npm-install-checks": {
@@ -4880,27 +5044,39 @@
                     }
                 },
                 "npm-packlist": {
-                    "version": "5.1.1",
+                    "version": "5.1.3",
                     "bundled": true,
                     "requires": {
                         "glob": "^8.0.1",
                         "ignore-walk": "^5.0.1",
-                        "npm-bundled": "^1.1.2",
-                        "npm-normalize-package-bin": "^1.0.1"
+                        "npm-bundled": "^2.0.0",
+                        "npm-normalize-package-bin": "^2.0.0"
+                    },
+                    "dependencies": {
+                        "npm-normalize-package-bin": {
+                            "version": "2.0.0",
+                            "bundled": true
+                        }
                     }
                 },
                 "npm-pick-manifest": {
-                    "version": "7.0.1",
+                    "version": "7.0.2",
                     "bundled": true,
                     "requires": {
                         "npm-install-checks": "^5.0.0",
-                        "npm-normalize-package-bin": "^1.0.1",
+                        "npm-normalize-package-bin": "^2.0.0",
                         "npm-package-arg": "^9.0.0",
                         "semver": "^7.3.5"
+                    },
+                    "dependencies": {
+                        "npm-normalize-package-bin": {
+                            "version": "2.0.0",
+                            "bundled": true
+                        }
                     }
                 },
                 "npm-profile": {
-                    "version": "6.2.0",
+                    "version": "6.2.1",
                     "bundled": true,
                     "requires": {
                         "npm-registry-fetch": "^13.0.1",
@@ -4908,7 +5084,7 @@
                     }
                 },
                 "npm-registry-fetch": {
-                    "version": "13.3.0",
+                    "version": "13.3.1",
                     "bundled": true,
                     "requires": {
                         "make-fetch-happen": "^10.0.6",
@@ -4953,7 +5129,7 @@
                     }
                 },
                 "pacote": {
-                    "version": "13.6.1",
+                    "version": "13.6.2",
                     "bundled": true,
                     "requires": {
                         "@npmcli/git": "^3.0.0",
@@ -4991,6 +5167,14 @@
                 "path-is-absolute": {
                     "version": "1.0.1",
                     "bundled": true
+                },
+                "postcss-selector-parser": {
+                    "version": "6.0.10",
+                    "bundled": true,
+                    "requires": {
+                        "cssesc": "^3.0.0",
+                        "util-deprecate": "^1.0.2"
+                    }
                 },
                 "proc-log": {
                     "version": "2.0.1",
@@ -5039,13 +5223,19 @@
                     "bundled": true
                 },
                 "read-package-json": {
-                    "version": "5.0.1",
+                    "version": "5.0.2",
                     "bundled": true,
                     "requires": {
                         "glob": "^8.0.1",
                         "json-parse-even-better-errors": "^2.3.1",
                         "normalize-package-data": "^4.0.0",
-                        "npm-normalize-package-bin": "^1.0.1"
+                        "npm-normalize-package-bin": "^2.0.0"
+                    },
+                    "dependencies": {
+                        "npm-normalize-package-bin": {
+                            "version": "2.0.0",
+                            "bundled": true
+                        }
                     }
                 },
                 "read-package-json-fast": {
@@ -5153,10 +5343,10 @@
                     "bundled": true
                 },
                 "socks": {
-                    "version": "2.6.2",
+                    "version": "2.7.0",
                     "bundled": true,
                     "requires": {
-                        "ip": "^1.1.5",
+                        "ip": "^2.0.0",
                         "smart-buffer": "^4.2.0"
                     }
                 },
@@ -5255,14 +5445,14 @@
                     "bundled": true
                 },
                 "unique-filename": {
-                    "version": "1.1.1",
+                    "version": "2.0.1",
                     "bundled": true,
                     "requires": {
-                        "unique-slug": "^2.0.0"
+                        "unique-slug": "^3.0.0"
                     }
                 },
                 "unique-slug": {
-                    "version": "2.0.2",
+                    "version": "3.0.0",
                     "bundled": true,
                     "requires": {
                         "imurmurhash": "^0.1.4"
@@ -5317,7 +5507,7 @@
                     "bundled": true
                 },
                 "write-file-atomic": {
-                    "version": "4.0.1",
+                    "version": "4.0.2",
                     "bundled": true,
                     "requires": {
                         "imurmurhash": "^0.1.4",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "@elastic/elasticsearch": "^7.16.0",
         "bufferutil": "^4.0.3",
         "cheerio": "^1.0.0-rc.10",
-        "discord.js": "^13.15.0",
+        "discord.js": "^13.16.0",
         "got": "^11.8.2",
         "install": "^0.13.0",
         "js-yaml": "^4.1.0",

--- a/src/autocompleteHandlers/compare.ts
+++ b/src/autocompleteHandlers/compare.ts
@@ -1,0 +1,24 @@
+import { ApplicationCommandOptionChoiceData, AutocompleteInteraction } from 'discord.js';
+import { NonCommandInteractionData } from '../eventHandlerTypes';
+import { fetchAutocompleteItemResults } from '../interactionLogic/search/search';
+import { SearchableItemCategory } from '../interactionLogic/search/types';
+import { compareCommandCategoryList } from '../interactionLogic/search/commandOptions';
+
+const itemNameAutocompleteInteration: NonCommandInteractionData = {
+    names: compareCommandCategoryList.map((category) => 'compare-' + category),
+    preferEphemeralErrorMessage: true,
+    run: async (interaction: AutocompleteInteraction, args, handlerName: string): Promise<void> => {
+        const autocompleteChoices: ApplicationCommandOptionChoiceData[] =
+            await fetchAutocompleteItemResults({
+                term: interaction.options.getFocused(),
+                itemSearchCategory:
+                    handlerName === 'compare-wep'
+                        ? 'weapon'
+                        : (handlerName.slice('compare-'.length) as SearchableItemCategory),
+            });
+
+        await interaction.respond(autocompleteChoices);
+    },
+};
+
+export default itemNameAutocompleteInteration;

--- a/src/autocompleteHandlers/compare.ts
+++ b/src/autocompleteHandlers/compare.ts
@@ -12,7 +12,7 @@ const itemNameAutocompleteInteration: NonCommandInteractionData = {
             await fetchAutocompleteItemResults({
                 term: interaction.options.getFocused(),
                 itemSearchCategory:
-                    handlerName === 'compare-wep'
+                    handlerName === 'compare-weapon'
                         ? 'weapon'
                         : (handlerName.slice('compare-'.length) as SearchableItemCategory),
             });

--- a/src/autocompleteHandlers/item.ts
+++ b/src/autocompleteHandlers/item.ts
@@ -1,5 +1,4 @@
 import { ApplicationCommandOptionChoiceData, AutocompleteInteraction } from 'discord.js';
-import { InteractionResponseTypes } from 'discord.js/typings/enums';
 import { NonCommandInteractionData } from '../eventHandlerTypes';
 import { fetchAutocompleteItemResults } from '../interactionLogic/search/search';
 import {
@@ -7,30 +6,10 @@ import {
     SearchableItemCategoryAlias,
 } from '../interactionLogic/search/types';
 import { unaliasItemType } from '../interactionLogic/search/utils';
-
-const commandNames: (SearchableItemCategory | SearchableItemCategoryAlias)[] = [
-    'item',
-    'wep',
-    'sword',
-    'axe',
-    'mace',
-    'staff',
-    'wand',
-    'dagger',
-    'scythe',
-    'acc',
-    'cape',
-    'helm',
-    'belt',
-    'necklace',
-    'ring',
-    'trinket',
-    'bracer',
-    'cosmetic',
-];
+import { searchCommandOptions } from '../interactionLogic/search/commandOptions';
 
 const itemNameAutocompleteInteration: NonCommandInteractionData = {
-    names: commandNames,
+    names: searchCommandOptions,
     preferEphemeralErrorMessage: true,
     run: async (
         interaction: AutocompleteInteraction,
@@ -47,19 +26,7 @@ const itemNameAutocompleteInteration: NonCommandInteractionData = {
                 maxLevel,
             });
 
-        // TODO: Replace the below code with the interaction.respond method once a hotfix is released,
-        //  since it is currently bugged
-        if (interaction.responded) throw new Error('INTERACTION_ALREADY_REPLIED');
-
-        // @ts-ignore
-        await interaction.client.api.interactions(interaction.id, interaction.token).callback.post({
-            data: {
-                type: InteractionResponseTypes.APPLICATION_COMMAND_AUTOCOMPLETE_RESULT,
-                data: { choices: autocompleteChoices },
-            },
-            auth: false,
-        });
-        interaction.responded = true;
+        await interaction.respond(autocompleteChoices);
     },
 };
 

--- a/src/chatCommands/compare.ts
+++ b/src/chatCommands/compare.ts
@@ -1,0 +1,62 @@
+import { GuildTextBasedChannel, Message } from 'discord.js';
+import { ChatCommandData } from '../eventHandlerTypes';
+import {
+    SearchableItemCategory,
+    SearchableItemCategoryAlias,
+} from '../interactionLogic/search/types';
+import { unaliasItemType } from '../interactionLogic/search/utils';
+import { ValidationError } from '../errors';
+import { getCompareResultMessage } from '../interactionLogic/search/formattedResults';
+
+const commandCategories: (SearchableItemCategory | SearchableItemCategoryAlias)[] = [
+    'wep',
+    'weap',
+    'weapon',
+    'cape',
+    'cloak',
+    'wing',
+    'helm',
+    'helmet',
+    'belt',
+    'necklace',
+    'neck',
+    'ring',
+    'trinket',
+    'bracer',
+];
+
+const command: ChatCommandData = {
+    names: commandCategories
+        .map((category) => 'compare-' + category)
+        .concat(commandCategories.map((category) => 'compare' + category))
+        .concat(commandCategories.map((category) => 'compare-' + category + 's'))
+        .concat(commandCategories.map((category) => 'compare' + category + 's')),
+    run: async (
+        message: Message,
+        itemsToCompareInput: string,
+        commandName: string
+    ): Promise<void> => {
+        const inputItemCategory: SearchableItemCategory | SearchableItemCategoryAlias = commandName
+            .replace(/^compare-?/, '')
+            .replace(/s$/, '') as SearchableItemCategory | SearchableItemCategoryAlias;
+        const itemSearchCategory: SearchableItemCategory = unaliasItemType(inputItemCategory);
+        const itemsToCompare: string[] = itemsToCompareInput
+            .split(',')
+            .map((itemNameInput) => itemNameInput.trim())
+            .slice(0, 2);
+        if (itemsToCompare.length < 2 || itemsToCompare.filter((item) => !!item).length < 2) {
+            throw new ValidationError('You must enter the names of two items to compare.');
+        }
+
+        const compareResultMessage = await getCompareResultMessage({
+            term1: itemsToCompare[0],
+            term2: itemsToCompare[1],
+            itemSearchCategory: itemSearchCategory,
+        });
+
+        const channel: GuildTextBasedChannel = message.channel as GuildTextBasedChannel;
+        await channel.send(compareResultMessage);
+    },
+};
+
+export default command;

--- a/src/chatCommands/item.ts
+++ b/src/chatCommands/item.ts
@@ -1,4 +1,4 @@
-import { Message, MessageOptions, TextChannel } from 'discord.js';
+import { Message, MessageOptions, GuildTextBasedChannel } from 'discord.js';
 import config from '../config';
 import { ChatCommandData } from '../eventHandlerTypes';
 import { getSearchResultMessagewithButtons } from '../interactionLogic/search/search';
@@ -9,10 +9,39 @@ import {
 import { unaliasItemType } from '../interactionLogic/search/utils';
 import { embed } from '../utils/misc';
 import { botResponseCache } from '../utils/store';
-import { searchCommandOptions } from '../interactionLogic/search/commandOptions';
+
+const commandNames: (SearchableItemCategory | SearchableItemCategoryAlias)[] = [
+    'item',
+    'wep',
+    'weap',
+    'weapon',
+    'sword',
+    'axe',
+    'mace',
+    'staff',
+    'wand',
+    'dagger',
+    'scythe',
+    'acc',
+    'accessory',
+    'cape',
+    'cloak',
+    'wings',
+    'wing',
+    'helm',
+    'helmet',
+    'belt',
+    'necklace',
+    'neck',
+    'ring',
+    'trinket',
+    'bracer',
+    'pet',
+    'cosmetic',
+];
 
 const command: ChatCommandData = {
-    names: searchCommandOptions,
+    names: commandNames,
     run: async (
         message: Message,
         itemNameToSearchFor: string,
@@ -20,7 +49,7 @@ const command: ChatCommandData = {
     ): Promise<void> => {
         const itemSearchCategory: SearchableItemCategory = unaliasItemType(commandName);
 
-        const channel: TextChannel = message.channel as TextChannel;
+        const channel: GuildTextBasedChannel = message.channel as GuildTextBasedChannel;
 
         if (!itemNameToSearchFor) {
             await channel.send(

--- a/src/chatCommands/item.ts
+++ b/src/chatCommands/item.ts
@@ -9,39 +9,10 @@ import {
 import { unaliasItemType } from '../interactionLogic/search/utils';
 import { embed } from '../utils/misc';
 import { botResponseCache } from '../utils/store';
-
-const commandNames: (SearchableItemCategory | SearchableItemCategoryAlias)[] = [
-    'item',
-    'wep',
-    'weap',
-    'weapon',
-    'sword',
-    'axe',
-    'mace',
-    'staff',
-    'wand',
-    'dagger',
-    'scythe',
-    'acc',
-    'accessory',
-    'cape',
-    'cloak',
-    'wings',
-    'wing',
-    'helm',
-    'helmet',
-    'belt',
-    'necklace',
-    'neck',
-    'ring',
-    'trinket',
-    'bracer',
-    'pet',
-    'cosmetic',
-];
+import { searchCommandOptions } from '../interactionLogic/search/commandOptions';
 
 const command: ChatCommandData = {
-    names: commandNames,
+    names: searchCommandOptions,
     run: async (
         message: Message,
         itemNameToSearchFor: string,

--- a/src/interactionLogic/search/commandOptions.ts
+++ b/src/interactionLogic/search/commandOptions.ts
@@ -23,4 +23,4 @@ export const searchCommandOptions: (SearchableItemCategory | SearchableItemCateg
 ];
 
 export const compareCommandCategoryList: (SearchableItemCategory | SearchableItemCategoryAlias)[] =
-    ['wep', 'belt', 'bracer', 'cape', 'helm', 'necklace', 'ring'];
+    ['weapon', 'belt', 'bracer', 'cape', 'helm', 'necklace', 'ring', 'trinket'];

--- a/src/interactionLogic/search/commandOptions.ts
+++ b/src/interactionLogic/search/commandOptions.ts
@@ -1,0 +1,25 @@
+import { SearchableItemCategory, SearchableItemCategoryAlias } from './types';
+
+export const searchCommandOptions: (SearchableItemCategory | SearchableItemCategoryAlias)[] = [
+    'item',
+    'wep',
+    'sword',
+    'axe',
+    'mace',
+    'staff',
+    'wand',
+    'dagger',
+    'scythe',
+    'acc',
+    'cape',
+    'helm',
+    'belt',
+    'necklace',
+    'ring',
+    'trinket',
+    'bracer',
+    'cosmetic',
+];
+
+export const compareCommandCategoryList: (SearchableItemCategory | SearchableItemCategoryAlias)[] =
+    ['wep', 'belt', 'bracer', 'cape', 'helm', 'necklace', 'ring'];

--- a/src/interactionLogic/search/commandOptions.ts
+++ b/src/interactionLogic/search/commandOptions.ts
@@ -19,6 +19,7 @@ export const searchCommandOptions: (SearchableItemCategory | SearchableItemCateg
     'trinket',
     'bracer',
     'cosmetic',
+    'pet',
 ];
 
 export const compareCommandCategoryList: (SearchableItemCategory | SearchableItemCategoryAlias)[] =

--- a/src/interactionLogic/search/formattedResults.ts
+++ b/src/interactionLogic/search/formattedResults.ts
@@ -70,6 +70,22 @@ function getFormattedBonusesOrResists(searchResultStats?: Stats) {
     );
 }
 
+function getFormattedDamageRange(searchResult: any) {
+    if (
+        searchResult.scaled_damage === undefined &&
+        searchResult.min_damage === undefined &&
+        searchResult.max_damage === undefined
+    ) {
+        return '';
+    }
+    return (
+        '**Damage:** ' +
+        (searchResult.scaled_damage
+            ? 'Scaled'
+            : `${searchResult.min_damage}-${searchResult.max_damage}`)
+    );
+}
+
 function getFormattedColorCustomInfo(searchResultColorCustomInfo?: string[]): string | undefined {
     if (!searchResultColorCustomInfo?.length) return;
 
@@ -349,11 +365,7 @@ function formatWeaponQueryResponse(searchResult: any): MessageEmbedOptions {
 
     const isCosmetic: boolean = searchResult.common_tags.includes('cosmetic');
     if (!isCosmetic) {
-        embedBody +=
-            `\n**Damage:** ` +
-            (searchResult.scaled_damage
-                ? 'Scaled'
-                : `${searchResult.min_damage}-${searchResult.max_damage}`);
+        embedBody += '\n' + getFormattedDamageRange(searchResult);
     }
 
     embedBody += `\n**Element:** ${
@@ -585,8 +597,10 @@ export async function getCompareResultMessage({
         item1SearchResult.resists
     );
 
+    const item1DamageDiff: string = getFormattedDamageRange(item1SearchResult);
     const item1Diff: string =
-        `**Tags:** ${getFormattedListOfItemTags(item1SearchResult.variant_info)}\n\n` +
+        `**Tags:** ${getFormattedListOfItemTags(item1SearchResult.variant_info)}\n` +
+        (item1DamageDiff ? item1DamageDiff + '\n' : '') +
         `__Greater Stats__\n` +
         `**Bonuses:** ${getFormattedBonusesOrResists(item1GreaterBonuses)}\n` +
         `**Resists:** ${getFormattedBonusesOrResists(item1GreaterResists)}\n` +
@@ -594,8 +608,10 @@ export async function getCompareResultMessage({
         `**Bonuses:** ${getFormattedBonusesOrResists(item1LesserBonuses)}\n` +
         `**Resists:** ${getFormattedBonusesOrResists(item1LesserResists)}\n`;
 
+    const item2DamageDiff: string = getFormattedDamageRange(item2SearchResult);
     const item2Diff: string =
-        `**Tags:** ${getFormattedListOfItemTags(item2SearchResult.variant_info)}\n\n` +
+        `**Tags:** ${getFormattedListOfItemTags(item2SearchResult.variant_info)}\n` +
+        (item2DamageDiff ? item2DamageDiff + '\n' : '') +
         `__Greater Stats__\n` +
         `**Bonuses:** ${getFormattedBonusesOrResists(item2GreaterBonuses)}\n` +
         `**Resists:** ${getFormattedBonusesOrResists(item2GreaterResists)}\n` +

--- a/src/interactionLogic/search/formattedResults.ts
+++ b/src/interactionLogic/search/formattedResults.ts
@@ -535,17 +535,20 @@ export async function getCompareResultMessage({
     term2: string;
     itemSearchCategory: SearchableItemCategory;
 }): Promise<Pick<MessageOptions, 'embeds'>> {
-    const item1SearchResultResponseBody = await fetchItemSearchResult({
-        term: term1,
-        itemSearchCategory: itemSearchCategory,
-    });
+    const [item1SearchResultResponseBody, item2SearchResultResponseBody] = await Promise.all([
+        fetchItemSearchResult({
+            term: term1,
+            itemSearchCategory: itemSearchCategory,
+        }),
+        fetchItemSearchResult({
+            term: term2,
+            itemSearchCategory: itemSearchCategory,
+        }),
+    ]);
+
     const item1SearchResult = (item1SearchResultResponseBody.hits?.hits ?? [])[0]?._source;
     if (!item1SearchResult) throw new ValidationError(`Search results for ${term1} not found.`);
 
-    const item2SearchResultResponseBody = await fetchItemSearchResult({
-        term: term2,
-        itemSearchCategory: itemSearchCategory,
-    });
     const item2SearchResult = (item2SearchResultResponseBody.hits?.hits ?? [])[0]?._source;
     if (!item2SearchResult) throw new ValidationError(`Search results for ${term2} not found.`);
 

--- a/src/interactionLogic/search/search.ts
+++ b/src/interactionLogic/search/search.ts
@@ -387,7 +387,7 @@ export async function fetchAutocompleteItemResults({
     );
 }
 
-async function fetchItemSearchResult({
+export async function fetchItemSearchResult({
     term,
     itemSearchCategory,
     maxLevel,
@@ -628,10 +628,10 @@ async function fetchItemSearchResult({
 
     // If the result was empty, check if the search query matches the family names
     // of other items
-    if (!responseBody.hits?.hits?.length) {
-        query.bool.should = getMatchQueryBody(unaliasedTokens, itemSearchCategory, true);
-        responseBody = (await elasticClient.search(searchQuery)).body;
-    }
+    // if (!responseBody.hits?.hits?.length) {
+    //     query.bool.should = getMatchQueryBody(unaliasedTokens, itemSearchCategory, true);
+    //     responseBody = (await elasticClient.search(searchQuery)).body;
+    // }
 
     return responseBody;
 }

--- a/src/interactionLogic/search/types.ts
+++ b/src/interactionLogic/search/types.ts
@@ -29,6 +29,8 @@ export type ItemVariantInfo = { tags: ItemTag[]; locations: Location[] };
 
 export type Stats = { [key: string]: string | number };
 
+export type ItemStats = { [key: string]: number };
+
 export type PetAttack = { appearance?: string | string[]; description: string };
 
 export type SearchableItemCategoryAlias =

--- a/src/interactionLogic/sort/commandOptions.ts
+++ b/src/interactionLogic/sort/commandOptions.ts
@@ -4,8 +4,8 @@ import {
     ApplicationCommandOptionData,
     ModalOptions,
 } from 'discord.js';
-import { ItemTag, PRETTY_TAG_NAMES } from '../../utils/itemTypeData';
-import { ITEM_TAG_FILTER_OPTION_NAMES, PRETTY_ITEM_TYPES } from './constants';
+import { ItemTag, PRETTY_ITEM_TYPES, PRETTY_TAG_NAMES } from '../../utils/itemTypeData';
+import { ITEM_TAG_FILTER_OPTION_NAMES } from './constants';
 import { SortCommandParams, SortItemTypeOption } from './types';
 
 function getItemTagFilterOptions(): ApplicationCommandNonOptionsData[] {

--- a/src/interactionLogic/sort/constants.ts
+++ b/src/interactionLogic/sort/constants.ts
@@ -35,19 +35,3 @@ export const SORTABLE_TAGS: ItemTag[] = [
     'temp',
     'none',
 ];
-
-export const PRETTY_ITEM_TYPES: { [key in ItemType]: string } = {
-    weapon: 'Weapons',
-    belt: 'Belts',
-    capeOrWings: 'Capes/Wings',
-    ring: 'Rings',
-    necklace: 'Necklaces',
-    helm: 'Helms',
-    bracer: 'Bracers',
-    trinket: 'Trinkets',
-};
-
-export const PRETTY_TO_BASE_ITEM_TYPE: { [key: string]: ItemType } = {};
-for (const itemType in PRETTY_ITEM_TYPES) {
-    PRETTY_TO_BASE_ITEM_TYPE[PRETTY_ITEM_TYPES[itemType as ItemType]] = itemType as ItemType;
-}

--- a/src/interactionLogic/sort/getSortedItemsResponse.ts
+++ b/src/interactionLogic/sort/getSortedItemsResponse.ts
@@ -12,10 +12,14 @@ import {
     MessageSelectOptionData,
 } from 'discord.js';
 import { INTERACTION_ID_ARG_SEPARATOR, MAX_EMBED_DESC_LENGTH } from '../../utils/constants';
-import { ItemTag, ItemType, PRETTY_TAG_NAMES } from '../../utils/itemTypeData';
 import {
+    ItemTag,
+    ItemType,
     PRETTY_ITEM_TYPES,
+    PRETTY_TAG_NAMES,
     PRETTY_TO_BASE_ITEM_TYPE,
+} from '../../utils/itemTypeData';
+import {
     QUERY_RESULT_LIMIT,
     QUERY_SHORT_RESULT_LIMIT,
     SORTABLE_TAGS,

--- a/src/slashCommands/compare.ts
+++ b/src/slashCommands/compare.ts
@@ -1,0 +1,55 @@
+import { ApplicationCommandOptionData, CommandInteraction } from 'discord.js';
+import { SlashCommandData } from '../eventHandlerTypes';
+import { getCompareResultMessage } from '../interactionLogic/search/formattedResults';
+import {
+    SearchableItemCategory,
+    SearchableItemCategoryAlias,
+} from '../interactionLogic/search/types';
+import { unaliasItemType } from '../interactionLogic/search/utils';
+import { compareCommandCategoryList } from '../interactionLogic/search/commandOptions';
+
+function createCompareSlashCommand(
+    inputItemCategory: SearchableItemCategory | SearchableItemCategoryAlias
+): SlashCommandData {
+    const itemCategory: SearchableItemCategory = unaliasItemType(inputItemCategory);
+
+    const commandOptions: ApplicationCommandOptionData[] = [
+        {
+            type: 'STRING',
+            name: `${itemCategory}-1`,
+            required: true,
+            description: `Name of ${itemCategory} 1 to compare`,
+            autocomplete: true,
+        },
+        {
+            type: 'STRING',
+            name: `${itemCategory}-2`,
+            required: true,
+            description: `Name of ${itemCategory} 2 to compare`,
+            autocomplete: true,
+        },
+    ];
+
+    return {
+        preferEphemeralErrorMessage: true,
+        structure: {
+            name: 'compare-' + itemCategory,
+            description: `Compare the bonuses and resists of two ${itemCategory}s`,
+            options: commandOptions,
+        },
+
+        run: async (interaction: CommandInteraction) => {
+            const compareResultMessage = await getCompareResultMessage({
+                term1: interaction.options.getString(`${itemCategory}-1`, true),
+                term2: interaction.options.getString(`${itemCategory}-2`, true),
+                itemSearchCategory: itemCategory,
+            });
+
+            await interaction.reply(compareResultMessage);
+        },
+    };
+}
+
+const commands: SlashCommandData[] = compareCommandCategoryList.map(createCompareSlashCommand);
+
+export default commands;

--- a/src/slashCommands/item.ts
+++ b/src/slashCommands/item.ts
@@ -10,6 +10,7 @@ import {
     SearchableItemCategoryAlias,
 } from '../interactionLogic/search/types';
 import { unaliasItemType } from '../interactionLogic/search/utils';
+import { searchCommandOptions } from '../interactionLogic/search/commandOptions';
 
 function createSearchSlashCommand(
     commandName: SearchableItemCategory | SearchableItemCategoryAlias
@@ -78,26 +79,6 @@ function createSearchSlashCommand(
     };
 }
 
-const categories: (SearchableItemCategory | SearchableItemCategoryAlias)[] = [
-    'item',
-    'wep',
-    'sword',
-    'axe',
-    'mace',
-    'staff',
-    'wand',
-    'dagger',
-    'scythe',
-    'acc',
-    'cape',
-    'helm',
-    'belt',
-    'necklace',
-    'ring',
-    'trinket',
-    'bracer',
-    'cosmetic',
-];
-const commands: SlashCommandData[] = categories.map(createSearchSlashCommand);
+const commands: SlashCommandData[] = searchCommandOptions.map(createSearchSlashCommand);
 
 export default commands;

--- a/src/utils/itemTypeData.ts
+++ b/src/utils/itemTypeData.ts
@@ -88,3 +88,19 @@ const BonusTypes = {
 };
 
 export type BonusType = keyof typeof BonusTypes;
+
+export const PRETTY_ITEM_TYPES: { [key in ItemType]: string } = {
+    weapon: 'Weapons',
+    belt: 'Belts',
+    capeOrWings: 'Capes/Wings',
+    ring: 'Rings',
+    necklace: 'Necklaces',
+    helm: 'Helms',
+    bracer: 'Bracers',
+    trinket: 'Trinkets',
+};
+
+export const PRETTY_TO_BASE_ITEM_TYPE: { [key: string]: ItemType } = {};
+for (const itemType in PRETTY_ITEM_TYPES) {
+    PRETTY_TO_BASE_ITEM_TYPE[PRETTY_ITEM_TYPES[itemType as ItemType]] = itemType as ItemType;
+}


### PR DESCRIPTION
- Update discord.js version to v13.16.0
- Introduce /compare command to compare stats of any two of the same type of equippable item
- Re-enable pet command, which was previously disabled by mistake